### PR TITLE
Added repository name as a new field in slack message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Added Repository title to the slack message. Makes it easier in Slack to see which repository the build is related to.
+
 # v1.1.2 - 6/22/2020
 
 - Describes which OAuth scopes are required in the docs.

--- a/__tests__/utils.spec.js
+++ b/__tests__/utils.spec.js
@@ -30,6 +30,16 @@ describe('Utils', () => {
     });
 
     describe('for push events', () => {
+      it('links to the repository', () => {
+        const attachments = buildSlackAttachments({ status: 'STARTED', color: 'good', github: GITHUB_PUSH_EVENT });
+
+        expect(attachments[0].fields.find(a => a.title === 'Repository')).toEqual({
+          title: 'Repository',
+          value: `<https://github.com/voxmedia/github-action-slack-notify-build | github-action-slack-notify-build>`,
+          short: false,
+        });
+      });
+
       it('links to the action workflow', () => {
         const attachments = buildSlackAttachments({ status: 'STARTED', color: 'good', github: GITHUB_PUSH_EVENT });
 
@@ -62,6 +72,16 @@ describe('Utils', () => {
     });
 
     describe('for PR events', () => {
+      it('links to the repository', () => {
+        const attachments = buildSlackAttachments({ status: 'STARTED', color: 'good', github: GITHUB_PUSH_EVENT });
+
+        expect(attachments[0].fields.find(a => a.title === 'Repository')).toEqual({
+          title: 'Repository',
+          value: `<https://github.com/voxmedia/github-action-slack-notify-build | github-action-slack-notify-build>`,
+          short: false,
+        });
+      });
+
       it('links to the action workflow', () => {
         const attachments = buildSlackAttachments({ status: 'STARTED', color: 'good', github: GITHUB_PR_EVENT });
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -9937,7 +9937,7 @@ function buildSlackAttachments({ status, color, github }) {
       color,
       fields: [
         {
-          title: 'Repo',
+          title: 'Repository',
           value: `<https://github.com/${owner}/${repo} | ${repo}>`,
           short: false,
         },

--- a/dist/index.js
+++ b/dist/index.js
@@ -9937,6 +9937,11 @@ function buildSlackAttachments({ status, color, github }) {
       color,
       fields: [
         {
+          title: 'Repo',
+          value: `<https://github.com/${owner}/${repo} | ${repo}>`,
+          short: false,
+        },
+        {
           title: 'Action',
           value: `<https://github.com/${owner}/${repo}/commit/${sha}/checks | ${workflow}>`,
           short: true,

--- a/src/utils.js
+++ b/src/utils.js
@@ -26,7 +26,7 @@ function buildSlackAttachments({ status, color, github }) {
       color,
       fields: [
         {
-          title: 'Repo',
+          title: 'Repository',
           value: `<https://github.com/${owner}/${repo} | ${repo}>`,
           short: false,
         },

--- a/src/utils.js
+++ b/src/utils.js
@@ -26,6 +26,11 @@ function buildSlackAttachments({ status, color, github }) {
       color,
       fields: [
         {
+          title: 'Repo',
+          value: `<https://github.com/${owner}/${repo} | ${repo}>`,
+          short: false,
+        },
+        {
           title: 'Action',
           value: `<https://github.com/${owner}/${repo}/commit/${sha}/checks | ${workflow}>`,
           short: true,


### PR DESCRIPTION
## Purpose
Added repository name as a new field in slack message. We use this action across multiple repos so it wasn't obvious what repository the notification was linked to.

## Important Changes
Added repository name as a new field in slack message

## Changelog

- [x] I have updated `CHANGELOG.md` under "Unreleased" with the changes included in this PR.
