### PR TITLE
Don't attempt to send Slack notifications on fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
         with:
           node-version: 12
       - name: Notify slack
+        # Don't attempt to send Slack notifications on fork PRs which don't have access to secrets
+        if: secrets.SLACK_BOT_TOKEN
         id: slack
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -39,6 +41,7 @@ jobs:
         env:
           CI: true
       - name: Notify slack success
+        if: secrets.SLACK_BOT_TOKEN
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         uses: ./

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
           node-version: 12
       - name: Notify slack
         # Don't attempt to send Slack notifications on fork PRs which don't have access to secrets
-        if: secrets.SLACK_BOT_TOKEN
+        if: env.SLACK_BOT_TOKEN
         id: slack
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -41,7 +41,7 @@ jobs:
         env:
           CI: true
       - name: Notify slack success
-        if: secrets.SLACK_BOT_TOKEN
+        if: env.SLACK_BOT_TOKEN
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         uses: ./


### PR DESCRIPTION
## Purpose
Only fire Slack notifications if a Slack Token secret is present. This prevents a failure on forked PRs, with whom GitHub Action secrets are not shared.
