### PR TITLE
Update link to Slack attachment colors reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The ID of the channel to post the message to. **Required** if no `channel` is pr
 
 ### `color`
 
-The color to use for the notification. Can be a hex value or any [valid Slack color level](https://api.slack.com/docs/message-attachments#color) (e.g. `good`). Defaults to `#cccccc`.
+The color to use for the notification. Can be a hex value or any [valid Slack color level](https://api.slack.com/reference/messaging/attachments#fields) (e.g. `good`). Defaults to `#cccccc`.
 
 ### `message_id`
 


### PR DESCRIPTION
##  Purpose

Updates a link to the Slack documentation to point to an up-to-date list of available attachment colors.

The previous link redirects from https://api.slack.com/docs/message-attachments#color to https://api.slack.com/messaging/composing/layouts#attachments and no longer contains the list of available colors.

Thanks!

## Important Changes

N/A

## Changelog

This change seems minimal enough to skip the CHANGELOG, but happy to add a line if requested.

- [ ] I have updated `CHANGELOG.md` under "Unreleased" with the changes included in this PR.
