### PR TITLE
bump Node.js 12 actions to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,5 +24,5 @@ outputs:
   message_id:
     description: 'The unique timestamp identifier of the Slack message sent'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
## Purpose
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: voxmedia/github-action-slack-notify-build

## Important Changes
runs:
  using: 'node16'